### PR TITLE
fix: Frontend Masters CTA hover

### DIFF
--- a/styles/courses.css
+++ b/styles/courses.css
@@ -96,6 +96,11 @@ header .cta-btn {
   align-items: center;
 }
 
+.cta-btn:hover {
+  background: #152837;
+  text-decoration: none;
+}
+
 .jumbotron {
   padding: 0;
 }


### PR DESCRIPTION
Hi, Frontend Masters CTA seems to be missing darker hover that's present in other places:

![cta-hover-before](https://github.com/user-attachments/assets/79fbba0f-cb83-4b82-8d37-338910a76e0c)

# After the change:

![cta-hover-after](https://github.com/user-attachments/assets/2ef07fd0-5029-407c-8a36-658d494bf310)
