### PR TITLE
feat: reorder breadcrumbs in the header

### DIFF
--- a/components/header.js
+++ b/components/header.js
@@ -8,21 +8,21 @@ export default function Header(props) {
   const { frontendMastersLink } = useContext(CourseContext);
   return (
     <header className="navbar">
-      <h1 className="navbar-brand">
-        <Link href="/">{props.title}</Link>
-      </h1>
-      <div className="navbar-info">
-        {frontendMastersLink ? (
-          <a href={frontendMastersLink} className="cta-btn">
-            Watch on Frontend Masters
-          </a>
-        ) : null}
+      <div className="navbar-location">
+        <h1 className="navbar-brand">
+          <Link href="/">{props.title}</Link>
+        </h1>
         {section ? (
           <h2>
             {section} <i className={`fas fa-${icon}`} /> {title}
           </h2>
         ) : null}
       </div>
+      {frontendMastersLink ? (
+        <a href={frontendMastersLink} className="cta-btn">
+          Watch on Frontend Masters
+        </a>
+      ) : null}
     </header>
   );
 }

--- a/styles/courses.css
+++ b/styles/courses.css
@@ -68,7 +68,7 @@ a {
   text-transform: uppercase;
 }
 
-.navbar-info {
+.navbar-location {
   display: flex;
   flex-direction: row;
   align-items: center;

--- a/styles/courses.css
+++ b/styles/courses.css
@@ -49,7 +49,7 @@ a {
   justify-content: space-between;
   align-items: center;
   background-color: var(--bg-main);
-  padding: 10px;
+  padding: 20px;
 }
 
 .navbar h1 {


### PR DESCRIPTION
Perhaps breadcrumbs would be happier next to course title?

# Before

<img width="1148" alt="breadcrumbs-before" src="https://github.com/user-attachments/assets/285bcd5b-765f-4d4f-ac4e-077c168f0d01">

# After

<img width="1096" alt="Screenshot 2024-08-21 at 10 29 22" src="https://github.com/user-attachments/assets/8c952b58-dc7b-4dd3-98da-6f17bb772bd2">

